### PR TITLE
A reproducer for https://github.com/rails/rails/issues/12330

### DIFF
--- a/activerecord/test/cases/hot_compatibility_test.rb
+++ b/activerecord/test/cases/hot_compatibility_test.rb
@@ -1,7 +1,9 @@
 require 'cases/helper'
+require 'support/connection_helper'
 
 class HotCompatibilityTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
+  include ConnectionHelper
 
   setup do
     @klass = Class.new(ActiveRecord::Base) do
@@ -12,10 +14,21 @@ class HotCompatibilityTest < ActiveRecord::TestCase
 
       def self.name; 'HotCompatibility'; end
     end
+
+    @klass_owner = Class.new(ActiveRecord::Base) do
+      connection.create_table :owner_hot_compatibilities, force: true do |t|
+        t.string :bar
+      end
+
+      def self.name; 'OwnerHotCompatibility'; end
+    end
   end
 
   teardown do
-    ActiveRecord::Base.connection.drop_table :hot_compatibilities
+    [:hot_compatibilities,
+     :owner_hot_compatibilities].each do |table|
+      ActiveRecord::Base.connection.drop_table table
+    end
   end
 
   test "insert after remove_column" do
@@ -50,5 +63,40 @@ class HotCompatibilityTest < ActiveRecord::TestCase
     record.save!
     record.reload
     assert_equal 'bar', record.foo
+  end
+
+  test "select in transaction after add_column" do
+    # Rails will clear the prepared statements on the connection that runs the
+    # migration, so we use two connections to simulate what would actually happen
+    # on a production system; we'd have one connection running the migration from
+    # the rake task ("ddl_connection" here), and we'd have another conneciton in the
+    # web workers.
+    run_without_connection do |original_connection|
+      ActiveRecord::Base.establish_connection(original_connection.merge(pool_size: 2))
+      begin
+        ddl_connection = ActiveRecord::Base.connection_pool.checkout
+        begin
+          record = @klass_owner.create! bar: 'bar'
+
+          # prepare the reload statement in a transaction
+          @klass_owner.transaction do
+            record.reload
+          end
+
+          # add a new column
+          ddl_connection.add_column :owner_hot_compatibilities, :baz, :string
+
+          # we can still reload the object in a transaction
+          @klass_owner.transaction do
+            record.reload
+            assert_equal 'bar', record.bar
+          end
+        ensure
+          ActiveRecord::Base.connection_pool.checkin ddl_connection
+        end
+      ensure
+        ActiveRecord::Base.clear_all_connections!
+      end
+    end
   end
 end


### PR DESCRIPTION
```
vagrant@rails-dev-box:/vagrant/rails/activerecord$ ARCONN=postgresql ruby -Itest test/cases/hot_compatibility_test.rb 
Using postgresql
Run options: --seed 18513

# Running:

.E.

Finished in 0.243053s, 12.3430 runs/s, 28.8003 assertions/s.

  1) Error:
HotCompatibilityTest#test_select_in_transaction_after_add_column:
PG::InFailedSqlTransaction: ERROR:  current transaction is aborted, commands ignored until end of transaction block

    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:179:in `exec'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:179:in `dealloc'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/statement_pool.rb:42:in `delete'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:604:in `rescue in exec_cache'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:585:in `exec_cache'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:572:in `execute_and_clear'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:160:in `exec_query'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:375:in `select_prepared'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:39:in `select_all'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
    /vagrant/rails/activerecord/lib/active_record/querying.rb:39:in `find_by_sql'
    /vagrant/rails/activerecord/lib/active_record/relation.rb:692:in `exec_queries'
    /vagrant/rails/activerecord/lib/active_record/relation.rb:573:in `load'
    /vagrant/rails/activerecord/lib/active_record/relation.rb:252:in `to_a'
    /vagrant/rails/activerecord/lib/active_record/relation/finder_methods.rb:470:in `find_take'
    /vagrant/rails/activerecord/lib/active_record/relation/finder_methods.rb:100:in `take'
    /vagrant/rails/activerecord/lib/active_record/relation/finder_methods.rb:437:in `find_one'
    /vagrant/rails/activerecord/lib/active_record/relation/finder_methods.rb:418:in `find_with_ids'
    /vagrant/rails/activerecord/lib/active_record/relation/finder_methods.rb:66:in `find'
    /vagrant/rails/activerecord/lib/active_record/querying.rb:3:in `find'
    /vagrant/rails/activerecord/lib/active_record/core.rb:143:in `find'
    /vagrant/rails/activerecord/lib/active_record/persistence.rb:429:in `block in reload'
    /vagrant/rails/activerecord/lib/active_record/scoping/default.rb:35:in `block in unscoped'
    /vagrant/rails/activerecord/lib/active_record/relation.rb:343:in `scoping'
    /vagrant/rails/activerecord/lib/active_record/scoping/default.rb:35:in `unscoped'
    /vagrant/rails/activerecord/lib/active_record/persistence.rb:429:in `reload'
    /vagrant/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:37:in `reload'
    /vagrant/rails/activerecord/lib/active_record/associations.rb:253:in `reload'
    /vagrant/rails/activerecord/lib/active_record/autosave_association.rb:235:in `reload'
    /vagrant/rails/activerecord/lib/active_record/aggregations.rb:13:in `reload'
    test/cases/hot_compatibility_test.rb:91:in `block (3 levels) in <class:HotCompatibilityTest>'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:222:in `block in transaction'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:183:in `within_new_transaction'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:222:in `transaction'
    /vagrant/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    test/cases/hot_compatibility_test.rb:90:in `block (2 levels) in <class:HotCompatibilityTest>'
    /vagrant/rails/activerecord/test/support/connection_helper.rb:4:in `run_without_connection'
    test/cases/hot_compatibility_test.rb:74:in `block in <class:HotCompatibilityTest>'

3 runs, 7 assertions, 0 failures, 1 errors, 0 skips
```
